### PR TITLE
feat(build): improve dependency error reporting in autogen scripts

### DIFF
--- a/autogen.sh
+++ b/autogen.sh
@@ -12,7 +12,7 @@ if [ -z "${LIBTOOLIZE}" ] && GLIBTOOLIZE="$(command -v glibtoolize)"; then
   export LIBTOOLIZE
 fi
 command -v autoreconf >/dev/null || \
-  (echo "configuration failed, please install autoconf first" && exit 1)
+  (echo "configuration failed, please install autoconf first" >&2 && exit 1)
 autoreconf --install --force --warnings=all
 
 if expr "'$(build-aux/config.guess --timestamp)" \< "'$(depends/config.guess --timestamp)" > /dev/null; then


### PR DESCRIPTION
Improve error reporting in `autogen.sh` (root directory) and `src/minisketch/autogen.sh` by redirecting the autoreconf dependency check's error message to stderr.

Add check for autoreconf dependency to `src/secp256k1/autogen.sh`.

## Impact

This PR modifies all three autogen build scripts:
1. `autogen.sh` (root directory)
2. `src/minisketch/autogen.sh`
3. `src/secp256k1/autogen.sh`

**`autogen.sh` (root directory) and `src/minisketch/autogen.sh`:**

   - No change to the functional behavior of these files.
   - Enhances error reporting by directing error messages to stderr, aligning with best practices.

**`src/secp256k1/autogen.sh`:**

   - Add a functional change to improves error handling to provide a more helpful message if autoreconf is not found.
   - Add a non-functional refactor to change the autoreconf optional arguments from `-if` to `--install --force`.
   - Both changes improve alignment between this script’s behavior with the other two `autogen.sh` scripts.

## Background

**`autogen.sh` (root directory):**

1. **9 years ago:** Added the check for the `autoreconf` dependency was added to the `autogen.sh` build script in the root directory. This check avoids a `not found` error because the next line runs autoreconf.

   - Original error message: `./autogen.sh: 9: ./autogen.sh: autoreconf: not found`
   - Updated error message: `configuration failed, please install autoconf first`
   - [Link to commit](https://github.com/bitcoin/bitcoin/commit/889426d37e331c9e6c914dae824663a7167effdf) to the commit.

2. **5 years ago:** Updated the check from `which` to `command -v` to improve portability and reliability as part of a large lint refactor.

   - [Link to commit](https://github.com/bitcoin/bitcoin/commit/1ac454a3844b9b8389de0f660fa9455c0efa7140#diff-7544c8642acdd15d295934770061473e64323316cd9797fb78c1830ebba08cf2L14) to that commit.

**`src/minisketch/autogen.sh`:**

1. **3 years ago:** Created the entire file with no other updates.

   - [Link to commit](https://github.com/bitcoin/bitcoin/commit/07f0a61ef711a2f75ded3d73545bfabdf2a64fef) to that commit.

**`src/secp256k1/autogen.sh`:**

1. **10 years ago:** Created the entire file with no other updates.

   - [Link to commit](https://github.com/bitcoin/bitcoin/commit/2245a95ce8b35db19526f0ed6cba1e9850108340)